### PR TITLE
Implement page for single news item and share functionality

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="AndroidDomInspection" enabled="false" level="ERROR" enabled_by_default="false" />
+  </profile>
+</component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'com.android.application'
 
 android {
+    dataBinding {
+        enabled = true
+    }
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.lms.mpasho_lms_news"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:dist="http://schemas.android.com/apk/distribution"
     package="com.lms.mpasho_lms_news">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <dist:module dist:instant="true" />
 
@@ -14,7 +14,10 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".view.details.NewsDetailActivity"
+            android:theme="@style/AppTheme.NoActionBar" />
+        <activity android:name=".view.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/lms/mpasho_lms_news/adapter/Adapter.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/adapter/Adapter.java
@@ -1,7 +1,6 @@
-package com.lms.mpasho_lms_news;
+package com.lms.mpasho_lms_news.adapter;
 
 import android.content.Context;
-import android.content.DialogInterface;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -9,7 +8,6 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
@@ -23,7 +21,9 @@ import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
 import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.RequestOptions;
 import com.bumptech.glide.request.target.Target;
+import com.lms.mpasho_lms_news.R;
 import com.lms.mpasho_lms_news.models.Article;
+import com.lms.mpasho_lms_news.util.Utils;
 
 import java.util.List;
 

--- a/app/src/main/java/com/lms/mpasho_lms_news/adapter/Adapter.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/adapter/Adapter.java
@@ -12,7 +12,6 @@ import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;

--- a/app/src/main/java/com/lms/mpasho_lms_news/api/ApiClient.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/api/ApiClient.java
@@ -14,8 +14,8 @@ import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 public class ApiClient {
-    public static final String BASE_URL = "https://newsapi.org/v2/";
-    public static Retrofit retrofit;
+    private static final String BASE_URL = "https://newsapi.org/v2/";
+    private static Retrofit retrofit;
 
     public static Retrofit getApiClient() {
         if (retrofit == null) {

--- a/app/src/main/java/com/lms/mpasho_lms_news/models/Article.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/models/Article.java
@@ -1,92 +1,17 @@
 package com.lms.mpasho_lms_news.models;
 
-import com.google.gson.annotations.Expose;
-import com.google.gson.annotations.SerializedName;
-
 
 public class Article {
 
-    @SerializedName("source")
-    @Expose
-    private Source source;
+    private final String source, author, title, description, url, urlToImage, publishedAt;
 
-    @SerializedName("author")
-    @Expose
-    private String author;
-
-    @SerializedName("title")
-    @Expose
-    private String title;
-
-    @SerializedName("description")
-    @Expose
-    private String description;
-
-    @SerializedName("url")
-    @Expose
-    private String url;
-
-    @SerializedName("urlToImage")
-    @Expose
-    private String urlToImage;
-
-    @SerializedName("publishedAt")
-    @Expose
-    private String publishedAt;
-
-    public Source getSource() {
-        return source;
-    }
-
-    public void setSource(Source source) {
+    public Article(String source, String author, String title, String description, String url, String urlToImage, String publishedAt) {
         this.source = source;
-    }
-
-    public String getAuthor() {
-        return author;
-    }
-
-    public void setAuthor(String author) {
         this.author = author;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
         this.title = title;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
         this.description = description;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public void setUrl(String url) {
         this.url = url;
-    }
-
-    public String getUrlToImage() {
-        return urlToImage;
-    }
-
-    public void setUrlToImage(String urlToImage) {
         this.urlToImage = urlToImage;
-    }
-
-    public String getPublishedAt() {
-        return publishedAt;
-    }
-
-    public void setPublishedAt(String publishedAt) {
         this.publishedAt = publishedAt;
     }
 }

--- a/app/src/main/java/com/lms/mpasho_lms_news/models/Article.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/models/Article.java
@@ -1,17 +1,92 @@
 package com.lms.mpasho_lms_news.models;
 
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
 
 public class Article {
 
-    private final String source, author, title, description, url, urlToImage, publishedAt;
+    @SerializedName("source")
+    @Expose
+    private Source source;
 
-    public Article(String source, String author, String title, String description, String url, String urlToImage, String publishedAt) {
+    @SerializedName("author")
+    @Expose
+    private String author;
+
+    @SerializedName("title")
+    @Expose
+    private String title;
+
+    @SerializedName("description")
+    @Expose
+    private String description;
+
+    @SerializedName("url")
+    @Expose
+    private String url;
+
+    @SerializedName("urlToImage")
+    @Expose
+    private String urlToImage;
+
+    @SerializedName("publishedAt")
+    @Expose
+    private String publishedAt;
+
+    public Source getSource() {
+        return source;
+    }
+
+    public void setSource(Source source) {
         this.source = source;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
         this.author = author;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
         this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
         this.description = description;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
         this.url = url;
+    }
+
+    public String getUrlToImage() {
+        return urlToImage;
+    }
+
+    public void setUrlToImage(String urlToImage) {
         this.urlToImage = urlToImage;
+    }
+
+    public String getPublishedAt() {
+        return publishedAt;
+    }
+
+    public void setPublishedAt(String publishedAt) {
         this.publishedAt = publishedAt;
     }
 }

--- a/app/src/main/java/com/lms/mpasho_lms_news/models/News.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/models/News.java
@@ -1,15 +1,45 @@
 package com.lms.mpasho_lms_news.models;
 
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
 
 public class News {
 
+    @SerializedName("status")
+    @Expose
+    private String status;
 
-    private final String status, article;
-    private final Integer totalResult;
+    @SerializedName("totalResult")
+    @Expose
+    private int totalResult;
 
-    public News(String status, String article, Integer totalResult) {
+    @SerializedName("articles")
+    @Expose
+    private List<Article> article;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
         this.status = status;
-        this.article = article;
+    }
+
+    public int getTotalResult() {
+        return totalResult;
+    }
+
+    public void setTotalResult(int totalResult) {
         this.totalResult = totalResult;
+    }
+
+    public List<Article> getArticle() {
+        return article;
+    }
+
+    public void setArticle(List<Article> article) {
+        this.article = article;
     }
 }

--- a/app/src/main/java/com/lms/mpasho_lms_news/models/News.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/models/News.java
@@ -1,45 +1,15 @@
 package com.lms.mpasho_lms_news.models;
 
-import com.google.gson.annotations.Expose;
-import com.google.gson.annotations.SerializedName;
-
-import java.util.List;
 
 public class News {
 
-    @SerializedName("status")
-    @Expose
-    private String status;
 
-    @SerializedName("totalResult")
-    @Expose
-    private int totalResult;
+    private final String status, article;
+    private final Integer totalResult;
 
-    @SerializedName("articles")
-    @Expose
-    private List<Article> article;
-
-    public String getStatus() {
-        return status;
-    }
-
-    public void setStatus(String status) {
+    public News(String status, String article, Integer totalResult) {
         this.status = status;
-    }
-
-    public int getTotalResult() {
-        return totalResult;
-    }
-
-    public void setTotalResult(int totalResult) {
-        this.totalResult = totalResult;
-    }
-
-    public List<Article> getArticle() {
-        return article;
-    }
-
-    public void setArticle(List<Article> article) {
         this.article = article;
+        this.totalResult = totalResult;
     }
 }

--- a/app/src/main/java/com/lms/mpasho_lms_news/models/Source.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/models/Source.java
@@ -1,31 +1,12 @@
 package com.lms.mpasho_lms_news.models;
 
-import com.google.gson.annotations.Expose;
-import com.google.gson.annotations.SerializedName;
 
 public class Source {
 
-    @SerializedName("id")
-    @Expose
-    private String id;
+    private final String id, name;
 
-    @SerializedName("name")
-    @Expose
-    private String name;
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
+    public Source(String id, String name) {
         this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
         this.name = name;
     }
 }

--- a/app/src/main/java/com/lms/mpasho_lms_news/models/Source.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/models/Source.java
@@ -1,12 +1,31 @@
 package com.lms.mpasho_lms_news.models;
 
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 
 public class Source {
 
-    private final String id, name;
+    @SerializedName("id")
+    @Expose
+    private String id;
 
-    public Source(String id, String name) {
+    @SerializedName("name")
+    @Expose
+    private String name;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
         this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
         this.name = name;
     }
 }

--- a/app/src/main/java/com/lms/mpasho_lms_news/util/Utils.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/util/Utils.java
@@ -13,7 +13,7 @@ import java.util.Random;
 
 public class Utils {
 
-    public static ColorDrawable[] vibrantLightColorList =
+    private static ColorDrawable[] vibrantLightColorList =
             {
                     new ColorDrawable(Color.parseColor("#ffeead")),
                     new ColorDrawable(Color.parseColor("#93cfb3")),
@@ -65,7 +65,7 @@ public class Utils {
         return country.toLowerCase();
     }
 
-    public static String getLanguage(){
+    public static String getLanguage() {
         Locale locale = Locale.getDefault();
         String country = String.valueOf(locale.getLanguage());
         return country.toLowerCase();

--- a/app/src/main/java/com/lms/mpasho_lms_news/util/Utils.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/util/Utils.java
@@ -1,4 +1,4 @@
-package com.lms.mpasho_lms_news;
+package com.lms.mpasho_lms_news.util;
 
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;

--- a/app/src/main/java/com/lms/mpasho_lms_news/view/MainActivity.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/view/MainActivity.java
@@ -3,7 +3,11 @@ package com.lms.mpasho_lms_news.view;
 import android.app.SearchManager;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
+import android.support.v4.app.ActivityOptionsCompat;
+import android.support.v4.util.Pair;
+import android.support.v4.view.ViewCompat;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.DefaultItemAnimator;
@@ -183,22 +187,14 @@ public class MainActivity extends AppCompatActivity implements SwipeRefreshLayou
                 intent.putExtra("source",  article.getSource().getName());
                 intent.putExtra("author",  article.getAuthor());
 
-                startActivity(intent);
+                Pair<View, String> pair;
+                pair = Pair.create((View)imageView, ViewCompat.getTransitionName(imageView));
+                ActivityOptionsCompat optionsCompat = ActivityOptionsCompat.makeSceneTransitionAnimation(
+                        MainActivity.this,
+                        pair
+                );
 
-//                Pair<View, String> pair;
-//                pair = Pair.create((View)imageView, ViewCompat.getTransitionName(imageView));
-//                ActivityOptionsCompat optionsCompat = ActivityOptionsCompat.makeSceneTransitionAnimation(
-//                        MainActivity.this,
-//                        pair
-//                );
-//
-//
-//                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-//                    startActivity(intent, optionsCompat.toBundle());
-//                }else {
-//                    startActivity(intent);
-//                }
-
+                startActivity(intent, optionsCompat.toBundle());
             }
         });
 

--- a/app/src/main/java/com/lms/mpasho_lms_news/view/MainActivity.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/view/MainActivity.java
@@ -3,7 +3,6 @@ package com.lms.mpasho_lms_news.view;
 import android.app.SearchManager;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v4.util.Pair;
@@ -18,19 +17,16 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.Button;
 import android.widget.ImageView;
-import android.widget.RelativeLayout;
-import android.widget.TextView;
 import android.widget.Toast;
 
-import com.lms.mpasho_lms_news.adapter.Adapter;
 import com.lms.mpasho_lms_news.R;
-import com.lms.mpasho_lms_news.util.Utils;
+import com.lms.mpasho_lms_news.adapter.Adapter;
 import com.lms.mpasho_lms_news.api.ApiClient;
 import com.lms.mpasho_lms_news.api.ApiInterface;
 import com.lms.mpasho_lms_news.models.Article;
 import com.lms.mpasho_lms_news.models.News;
+import com.lms.mpasho_lms_news.util.Utils;
 import com.lms.mpasho_lms_news.view.details.NewsDetailActivity;
 
 import java.util.ArrayList;
@@ -48,10 +44,6 @@ public class MainActivity extends AppCompatActivity implements SwipeRefreshLayou
     private List<Article> articles = new ArrayList<>();
     private Adapter adapter;
     private SwipeRefreshLayout swipeRefreshLayout;
-    private RelativeLayout errorLayout;
-    private ImageView errorImage;
-    private TextView errorTitle, errorMessage;
-    private Button btnRetry;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -69,7 +61,7 @@ public class MainActivity extends AppCompatActivity implements SwipeRefreshLayou
         recyclerView.setItemAnimator(new DefaultItemAnimator());
         recyclerView.setNestedScrollingEnabled(false);
 
-       onLoadingSwipeRefresh("");
+        onLoadingSwipeRefresh("");
 
     }
 
@@ -128,7 +120,7 @@ public class MainActivity extends AppCompatActivity implements SwipeRefreshLayou
     public boolean onCreateOptionsMenu(Menu menu) {
 
         MenuInflater inflater = getMenuInflater();
-       inflater.inflate(R.menu.menu_main, menu);
+        inflater.inflate(R.menu.menu_main, menu);
         SearchManager searchManager = (SearchManager) getSystemService(Context.SEARCH_SERVICE);
         final SearchView searchView = (SearchView) menu.findItem(R.id.action_search).getActionView();
         MenuItem searchMenuItem = menu.findItem(R.id.action_search);
@@ -138,7 +130,7 @@ public class MainActivity extends AppCompatActivity implements SwipeRefreshLayou
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
             @Override
             public boolean onQueryTextSubmit(String query) {
-                if (query.length() > 2){
+                if (query.length() > 2) {
                     onLoadingSwipeRefresh(query);
                 }
                 return false;
@@ -171,7 +163,7 @@ public class MainActivity extends AppCompatActivity implements SwipeRefreshLayou
         );
     }
 
-    private void initListener(){
+    private void initListener() {
 
         adapter.setOnItemClickListener(new Adapter.OnItemClickListener() {
             @Override
@@ -182,13 +174,13 @@ public class MainActivity extends AppCompatActivity implements SwipeRefreshLayou
                 Article article = articles.get(position);
                 intent.putExtra("url", article.getUrl());
                 intent.putExtra("title", article.getTitle());
-                intent.putExtra("img",  article.getUrlToImage());
-                intent.putExtra("date",  article.getPublishedAt());
-                intent.putExtra("source",  article.getSource().getName());
-                intent.putExtra("author",  article.getAuthor());
+                intent.putExtra("img", article.getUrlToImage());
+                intent.putExtra("date", article.getPublishedAt());
+                intent.putExtra("source", article.getSource().getName());
+                intent.putExtra("author", article.getAuthor());
 
                 Pair<View, String> pair;
-                pair = Pair.create((View)imageView, ViewCompat.getTransitionName(imageView));
+                pair = Pair.create((View) imageView, ViewCompat.getTransitionName(imageView));
                 ActivityOptionsCompat optionsCompat = ActivityOptionsCompat.makeSceneTransitionAnimation(
                         MainActivity.this,
                         pair

--- a/app/src/main/java/com/lms/mpasho_lms_news/view/MainActivity.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/view/MainActivity.java
@@ -21,8 +21,6 @@ import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import android.widget.Toast;
-
 import com.lms.mpasho_lms_news.R;
 import com.lms.mpasho_lms_news.adapter.Adapter;
 import com.lms.mpasho_lms_news.api.ApiClient;

--- a/app/src/main/java/com/lms/mpasho_lms_news/view/MainActivity.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/view/MainActivity.java
@@ -1,7 +1,8 @@
-package com.lms.mpasho_lms_news;
+package com.lms.mpasho_lms_news.view;
 
 import android.app.SearchManager;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.AppCompatActivity;
@@ -12,16 +13,21 @@ import android.support.v7.widget.SearchView;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.lms.mpasho_lms_news.adapter.Adapter;
+import com.lms.mpasho_lms_news.R;
+import com.lms.mpasho_lms_news.util.Utils;
 import com.lms.mpasho_lms_news.api.ApiClient;
 import com.lms.mpasho_lms_news.api.ApiInterface;
 import com.lms.mpasho_lms_news.models.Article;
 import com.lms.mpasho_lms_news.models.News;
+import com.lms.mpasho_lms_news.view.details.NewsDetailActivity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -96,6 +102,8 @@ public class MainActivity extends AppCompatActivity implements SwipeRefreshLayou
                     recyclerView.setAdapter(adapter);
                     adapter.notifyDataSetChanged();
 
+                    initListener();
+
                     swipeRefreshLayout.setRefreshing(false);
 
                 } else {
@@ -157,5 +165,42 @@ public class MainActivity extends AppCompatActivity implements SwipeRefreshLayou
                     }
                 }
         );
+    }
+
+    private void initListener(){
+
+        adapter.setOnItemClickListener(new Adapter.OnItemClickListener() {
+            @Override
+            public void onItemClick(View view, int position) {
+                ImageView imageView = view.findViewById(R.id.img);
+                Intent intent = new Intent(MainActivity.this, NewsDetailActivity.class);
+
+                Article article = articles.get(position);
+                intent.putExtra("url", article.getUrl());
+                intent.putExtra("title", article.getTitle());
+                intent.putExtra("img",  article.getUrlToImage());
+                intent.putExtra("date",  article.getPublishedAt());
+                intent.putExtra("source",  article.getSource().getName());
+                intent.putExtra("author",  article.getAuthor());
+
+                startActivity(intent);
+
+//                Pair<View, String> pair;
+//                pair = Pair.create((View)imageView, ViewCompat.getTransitionName(imageView));
+//                ActivityOptionsCompat optionsCompat = ActivityOptionsCompat.makeSceneTransitionAnimation(
+//                        MainActivity.this,
+//                        pair
+//                );
+//
+//
+//                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+//                    startActivity(intent, optionsCompat.toBundle());
+//                }else {
+//                    startActivity(intent);
+//                }
+
+            }
+        });
+
     }
 }

--- a/app/src/main/java/com/lms/mpasho_lms_news/view/MainActivity.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/view/MainActivity.java
@@ -17,7 +17,10 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.Button;
 import android.widget.ImageView;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.lms.mpasho_lms_news.R;
@@ -44,6 +47,10 @@ public class MainActivity extends AppCompatActivity implements SwipeRefreshLayou
     private List<Article> articles = new ArrayList<>();
     private Adapter adapter;
     private SwipeRefreshLayout swipeRefreshLayout;
+    private RelativeLayout errorLayout;
+    private ImageView errorImage;
+    private TextView errorTitle, errorMessage;
+    private Button btnRetry;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -63,11 +70,18 @@ public class MainActivity extends AppCompatActivity implements SwipeRefreshLayou
 
         onLoadingSwipeRefresh("");
 
+        errorLayout = findViewById(R.id.errorLayout);
+        errorImage = findViewById(R.id.errorImage);
+        errorTitle = findViewById(R.id.errorTitle);
+        errorMessage = findViewById(R.id.errorMessage);
+        btnRetry = findViewById(R.id.btnRetry);
+
     }
 
 
-    public void LoadJson(final String keyword) {
+    public void loadJson(final String keyword) {
 
+        errorLayout.setVisibility(View.GONE);
         swipeRefreshLayout.setRefreshing(true);
 
         ApiInterface apiInterface = ApiClient.getApiClient().create(ApiInterface.class);
@@ -105,13 +119,35 @@ public class MainActivity extends AppCompatActivity implements SwipeRefreshLayou
                 } else {
 
                     swipeRefreshLayout.setRefreshing(false);
-                    Toast.makeText(MainActivity.this, "No Result", Toast.LENGTH_LONG).show();
+                    String errorCode;
+                    switch (response.code()) {
+                        case 404:
+                            errorCode = getString(R.string.error_404);
+                            break;
+                        case 500:
+                            errorCode = getString(R.string.error_500);
+                            break;
+                        default:
+                            errorCode = getString(R.string.error_unknown);
+                            break;
+                    }
+
+                    showErrorMessage(
+                            R.drawable.no_result,
+                            getString(R.string.no_result),
+                            getString(R.string.try_again) + errorCode
+                    );
                 }
             }
 
             @Override
             public void onFailure(Call<News> call, Throwable t) {
                 swipeRefreshLayout.setRefreshing(false);
+                showErrorMessage(
+                        R.drawable.oops,
+                        getString(R.string.oops),
+                        getString(R.string.error_network_failure) +
+                                t.toString());
             }
         });
     }
@@ -149,7 +185,7 @@ public class MainActivity extends AppCompatActivity implements SwipeRefreshLayou
 
     @Override
     public void onRefresh() {
-        LoadJson("");
+        loadJson("");
     }
 
     private void onLoadingSwipeRefresh(final String keyword) {
@@ -157,7 +193,7 @@ public class MainActivity extends AppCompatActivity implements SwipeRefreshLayou
                 new Runnable() {
                     @Override
                     public void run() {
-                        LoadJson(keyword);
+                        loadJson(keyword);
                     }
                 }
         );
@@ -187,6 +223,24 @@ public class MainActivity extends AppCompatActivity implements SwipeRefreshLayou
                 );
 
                 startActivity(intent, optionsCompat.toBundle());
+            }
+        });
+    }
+
+    private void showErrorMessage(int imageView, String title, String message){
+
+        if (errorLayout.getVisibility() == View.GONE) {
+            errorLayout.setVisibility(View.VISIBLE);
+        }
+
+        errorImage.setImageResource(imageView);
+        errorTitle.setText(title);
+        errorMessage.setText(message);
+
+        btnRetry.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                onLoadingSwipeRefresh("");
             }
         });
 

--- a/app/src/main/java/com/lms/mpasho_lms_news/view/details/NewsDetailActivity.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/view/details/NewsDetailActivity.java
@@ -158,12 +158,12 @@ public class NewsDetailActivity extends AppCompatActivity implements AppBarLayou
                 Intent i = new Intent(Intent.ACTION_SEND);
                 i.setType("text/plan");
                 i.putExtra(Intent.EXTRA_SUBJECT, mSource);
-                String body = mTitle + "\n" + mUrl + "\n" + "Share from the News App" + "\n";
+                String body = mTitle + "\n" + mUrl + "\n" + getString(R.string.sahre_from) + "\n";
                 i.putExtra(Intent.EXTRA_TEXT, body);
-                startActivity(Intent.createChooser(i, "Share with :"));
+                startActivity(Intent.createChooser(i, getString(R.string.share_with)));
 
             } catch (Exception e) {
-                Toast.makeText(this, "Hmm.. Sorry, \nCannot be shared", Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, getString(R.string.cannot_share), Toast.LENGTH_SHORT).show();
             }
         }
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/com/lms/mpasho_lms_news/view/details/NewsDetailActivity.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/view/details/NewsDetailActivity.java
@@ -1,0 +1,135 @@
+package com.lms.mpasho_lms_news.view.details;
+
+import android.content.Intent;
+import android.support.design.widget.AppBarLayout;
+import android.support.design.widget.CollapsingToolbarLayout;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.support.v7.widget.Toolbar;
+import android.view.View;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
+import com.bumptech.glide.request.RequestOptions;
+import com.lms.mpasho_lms_news.R;
+import com.lms.mpasho_lms_news.util.Utils;
+
+public class NewsDetailActivity extends AppCompatActivity implements AppBarLayout.OnOffsetChangedListener{
+
+    private ImageView imageView;
+    private TextView appbar_title, appbar_subtitle, date, time, title;
+    private boolean isHideToolbarView = false;
+    private FrameLayout date_behavior;
+    private LinearLayout titleAppbar;
+    private AppBarLayout appBarLayout;
+    private Toolbar toolbar;
+    private String mUrl, mImg, mTitle, mDate, mSource, mAuthor;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_news_detail);
+
+        toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+        getSupportActionBar().setTitle("");
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+        final CollapsingToolbarLayout collapsingToolbarLayout = findViewById(R.id.collapsing_toolbar);
+        collapsingToolbarLayout.setTitle("");
+
+        appBarLayout = findViewById(R.id.appbar);
+        appBarLayout.addOnOffsetChangedListener(this);
+        date_behavior = findViewById(R.id.date_behavior);
+        titleAppbar = findViewById(R.id.title_appbar);
+        imageView = findViewById(R.id.backdrop);
+        appbar_title = findViewById(R.id.title_on_appbar);
+        appbar_subtitle = findViewById(R.id.subtitle_on_appbar);
+        date = findViewById(R.id.date);
+        time = findViewById(R.id.time);
+        title = findViewById(R.id.title);
+
+        Intent intent = getIntent();
+        mUrl = intent.getStringExtra("url");
+        mImg = intent.getStringExtra("img");
+        mTitle = intent.getStringExtra("title");
+        mDate = intent.getStringExtra("date");
+        mSource = intent.getStringExtra("source");
+        mAuthor = intent.getStringExtra("author");
+
+        RequestOptions requestOptions = new RequestOptions();
+        requestOptions.error(Utils.getRandomDrawbleColor());
+
+        Glide.with(this)
+                .load(mImg)
+                .apply(requestOptions)
+                .transition(DrawableTransitionOptions.withCrossFade())
+                .into(imageView);
+
+        appbar_title.setText(mSource);
+        appbar_subtitle.setText(mUrl);
+        date.setText(Utils.DateFormat(mDate));
+        title.setText(mTitle);
+
+        String author;
+        if (mAuthor != null){
+            author = " \u2022 " + mAuthor;
+        } else {
+            author = "";
+        }
+
+        time.setText(mSource + author + " \u2022 " + Utils.DateToTimeFormat(mDate));
+
+        initWebView(mUrl);
+
+    }
+
+    private void initWebView(String url){
+        WebView webView = findViewById(R.id.webView);
+        webView.getSettings().setLoadsImagesAutomatically(true);
+        webView.getSettings().setJavaScriptEnabled(true);
+        webView.getSettings().setDomStorageEnabled(true);
+        webView.getSettings().setSupportZoom(true);
+        webView.getSettings().setBuiltInZoomControls(true);
+        webView.getSettings().setDisplayZoomControls(false);
+        webView.setScrollBarStyle(View.SCROLLBARS_INSIDE_OVERLAY);
+        webView.setWebViewClient(new WebViewClient());
+        webView.loadUrl(url);
+    }
+
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        supportFinishAfterTransition();
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        onBackPressed();
+        return true;
+    }
+
+    @Override
+    public void onOffsetChanged(AppBarLayout appBarLayout, int i) {
+        int maxScroll = appBarLayout.getTotalScrollRange();
+        float percentage = (float) Math.abs(i) / (float) maxScroll;
+
+        if (percentage == 1f && isHideToolbarView) {
+            date_behavior.setVisibility(View.GONE);
+            titleAppbar.setVisibility(View.VISIBLE);
+            isHideToolbarView = !isHideToolbarView;
+
+        } else if (percentage < 1f && !isHideToolbarView) {
+            date_behavior.setVisibility(View.VISIBLE);
+            titleAppbar.setVisibility(View.GONE);
+            isHideToolbarView = !isHideToolbarView;
+        }
+
+    }
+}

--- a/app/src/main/java/com/lms/mpasho_lms_news/view/details/NewsDetailActivity.java
+++ b/app/src/main/java/com/lms/mpasho_lms_news/view/details/NewsDetailActivity.java
@@ -1,11 +1,14 @@
 package com.lms.mpasho_lms_news.view.details;
 
 import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
 import android.support.design.widget.AppBarLayout;
 import android.support.design.widget.CollapsingToolbarLayout;
 import android.support.v7.app.AppCompatActivity;
-import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -13,6 +16,7 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
@@ -20,48 +24,48 @@ import com.bumptech.glide.request.RequestOptions;
 import com.lms.mpasho_lms_news.R;
 import com.lms.mpasho_lms_news.util.Utils;
 
-public class NewsDetailActivity extends AppCompatActivity implements AppBarLayout.OnOffsetChangedListener{
+import java.util.Objects;
 
-    private ImageView imageView;
-    private TextView appbar_title, appbar_subtitle, date, time, title;
+public class NewsDetailActivity extends AppCompatActivity implements AppBarLayout.OnOffsetChangedListener {
+
     private boolean isHideToolbarView = false;
     private FrameLayout date_behavior;
     private LinearLayout titleAppbar;
-    private AppBarLayout appBarLayout;
-    private Toolbar toolbar;
-    private String mUrl, mImg, mTitle, mDate, mSource, mAuthor;
+    private String mUrl;
+    private String mTitle;
+    private String mSource;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_news_detail);
 
-        toolbar = findViewById(R.id.toolbar);
+        Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
-        getSupportActionBar().setTitle("");
+        Objects.requireNonNull(getSupportActionBar()).setTitle("");
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         final CollapsingToolbarLayout collapsingToolbarLayout = findViewById(R.id.collapsing_toolbar);
         collapsingToolbarLayout.setTitle("");
 
-        appBarLayout = findViewById(R.id.appbar);
+        AppBarLayout appBarLayout = findViewById(R.id.appbar);
         appBarLayout.addOnOffsetChangedListener(this);
         date_behavior = findViewById(R.id.date_behavior);
         titleAppbar = findViewById(R.id.title_appbar);
-        imageView = findViewById(R.id.backdrop);
-        appbar_title = findViewById(R.id.title_on_appbar);
-        appbar_subtitle = findViewById(R.id.subtitle_on_appbar);
-        date = findViewById(R.id.date);
-        time = findViewById(R.id.time);
-        title = findViewById(R.id.title);
+        ImageView imageView = findViewById(R.id.backdrop);
+        TextView appbar_title = findViewById(R.id.title_on_appbar);
+        TextView appbar_subtitle = findViewById(R.id.subtitle_on_appbar);
+        TextView date = findViewById(R.id.date);
+        TextView time = findViewById(R.id.time);
+        TextView title = findViewById(R.id.title);
 
         Intent intent = getIntent();
         mUrl = intent.getStringExtra("url");
-        mImg = intent.getStringExtra("img");
+        String mImg = intent.getStringExtra("img");
         mTitle = intent.getStringExtra("title");
-        mDate = intent.getStringExtra("date");
+        String mDate = intent.getStringExtra("date");
         mSource = intent.getStringExtra("source");
-        mAuthor = intent.getStringExtra("author");
+        String mAuthor = intent.getStringExtra("author");
 
         RequestOptions requestOptions = new RequestOptions();
         requestOptions.error(Utils.getRandomDrawbleColor());
@@ -78,7 +82,7 @@ public class NewsDetailActivity extends AppCompatActivity implements AppBarLayou
         title.setText(mTitle);
 
         String author;
-        if (mAuthor != null){
+        if (mAuthor != null) {
             author = " \u2022 " + mAuthor;
         } else {
             author = "";
@@ -90,7 +94,7 @@ public class NewsDetailActivity extends AppCompatActivity implements AppBarLayou
 
     }
 
-    private void initWebView(String url){
+    private void initWebView(String url) {
         WebView webView = findViewById(R.id.webView);
         webView.getSettings().setLoadsImagesAutomatically(true);
         webView.getSettings().setJavaScriptEnabled(true);
@@ -130,6 +134,38 @@ public class NewsDetailActivity extends AppCompatActivity implements AppBarLayou
             titleAppbar.setVisibility(View.GONE);
             isHideToolbarView = !isHideToolbarView;
         }
+    }
 
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.menu_share, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+
+        int id = item.getItemId();
+
+        if (id == R.id.view_web) {
+            Intent i = new Intent(Intent.ACTION_VIEW);
+            i.setData(Uri.parse(mUrl));
+            startActivity(i);
+            return true;
+        } else if (id == R.id.share) {
+            try {
+
+                Intent i = new Intent(Intent.ACTION_SEND);
+                i.setType("text/plan");
+                i.putExtra(Intent.EXTRA_SUBJECT, mSource);
+                String body = mTitle + "\n" + mUrl + "\n" + "Share from the News App" + "\n";
+                i.putExtra(Intent.EXTRA_TEXT, body);
+                startActivity(Intent.createChooser(i, "Share with :"));
+
+            } catch (Exception e) {
+                Toast.makeText(this, "Hmm.. Sorry, \nCannot be shared", Toast.LENGTH_SHORT).show();
+            }
+        }
+        return super.onOptionsItemSelected(item);
     }
 }

--- a/app/src/main/res/layout-v21/error.xml
+++ b/app/src/main/res/layout-v21/error.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:id="@+id/errorLayout"
+    android:paddingLeft="16dp"
+    android:paddingRight="16dp"
+    android:background="@color/colorBackground"
+    android:visibility="gone">
+
+    <ImageView
+        android:id="@+id/errorImage"
+        android:src="@drawable/no_result"
+        android:layout_width="320dp"
+        android:layout_height="320dp"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="64dp"
+        android:contentDescription="@string/error_string" />
+
+    <TextView
+        android:id="@+id/errorTitle"
+        android:text="@string/error_title"
+        android:textColor="@color/colorTextTitle"
+        android:textStyle="bold"
+        android:fontFamily="sans-serif-light"
+        android:layout_centerHorizontal="true"
+        android:layout_below="@id/errorImage"
+        android:gravity="center_horizontal"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <TextView
+        android:id="@+id/errorMessage"
+        android:text="@string/error_message"
+        android:textColor="@color/colorTextSubtitle"
+        android:layout_centerHorizontal="true"
+        android:layout_below="@id/errorTitle"
+        android:gravity="center_horizontal"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+    <Button
+        android:id="@+id/btnRetry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/retry"
+        android:backgroundTint="@color/colorAccent"
+        android:textColor="#fff"
+        android:layout_below="@id/errorMessage"
+        android:layout_marginTop="16dp"
+        android:layout_centerHorizontal="true"/>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity"
+    tools:context=".view.MainActivity"
     android:background="@color/colorBackground">
 
     <android.support.v4.widget.SwipeRefreshLayout

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -43,4 +43,6 @@
             </LinearLayout>
         </android.support.v4.widget.NestedScrollView>
     </android.support.v4.widget.SwipeRefreshLayout>
+
+    <include layout="@layout/error" />
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,33 +7,40 @@
     tools:context=".MainActivity"
     android:background="@color/colorBackground">
 
-    <android.support.v4.widget.NestedScrollView
+    <android.support.v4.widget.SwipeRefreshLayout
+        android:id="@+id/swipe_refresh_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-        
-        <LinearLayout
-            android:orientation="vertical"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:background="@color/colorBackground">
 
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:textStyle="bold"
-                android:text="@string/app_headline"
-                android:fontFamily="sans-serif-light"
-                android:textSize="16sp"
-                android:layout_marginLeft="16dp"
-                android:layout_marginRight="16dp"
-                android:layout_marginTop="10dp"/>
+        <android.support.v4.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
 
-            <android.support.v7.widget.RecyclerView
-                android:id="@+id/recyclerView"
-                android:scrollbars="vertical"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-            </android.support.v7.widget.RecyclerView>
+            <LinearLayout
+                android:orientation="vertical"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent">
 
-        </LinearLayout>
-    </android.support.v4.widget.NestedScrollView>
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textStyle="bold"
+                    android:text="@string/app_headline"
+                    android:fontFamily="sans-serif-light"
+                    android:textSize="16sp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginRight="16dp"
+                    android:layout_marginTop="10dp"/>
+
+                <android.support.v7.widget.RecyclerView
+                    android:id="@+id/recyclerView"
+                    android:scrollbars="vertical"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+                </android.support.v7.widget.RecyclerView>
+
+            </LinearLayout>
+        </android.support.v4.widget.NestedScrollView>
+    </android.support.v4.widget.SwipeRefreshLayout>
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,20 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<layout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:context=".view.MainActivity"
-    android:background="@color/colorBackground">
-
-    <data>
-        name= "articles"
-        type =
-    </data>
-
     <LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+         tools:context=".view.MainActivity"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:background="@color/colorBackground" >
 
         <android.support.v4.widget.SwipeRefreshLayout
             android:id="@+id/swipe_refresh_layout"
@@ -54,6 +47,5 @@
         </android.support.v4.widget.SwipeRefreshLayout>
 
         <include layout="@layout/error" />
-    </LinearLayout>
 
-</layout>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,48 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+
+<layout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
     tools:context=".view.MainActivity"
     android:background="@color/colorBackground">
 
-    <android.support.v4.widget.SwipeRefreshLayout
-        android:id="@+id/swipe_refresh_layout"
+    <data>
+        name= "articles"
+        type =
+    </data>
+
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/colorBackground">
+        android:orientation="horizontal">
 
-        <android.support.v4.widget.NestedScrollView
+        <android.support.v4.widget.SwipeRefreshLayout
+            android:id="@+id/swipe_refresh_layout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="match_parent"
+            android:background="@color/colorBackground">
 
-            <LinearLayout
-                android:orientation="vertical"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent">
+            <android.support.v4.widget.NestedScrollView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
 
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:textStyle="bold"
-                    android:text="@string/app_headline"
-                    android:fontFamily="sans-serif-light"
-                    android:textSize="16sp"
-                    android:layout_marginLeft="16dp"
-                    android:layout_marginRight="16dp"
-                    android:layout_marginTop="10dp"/>
+                <LinearLayout
+                    android:orientation="vertical"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent">
 
-                <android.support.v7.widget.RecyclerView
-                    android:id="@+id/recyclerView"
-                    android:scrollbars="vertical"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-                </android.support.v7.widget.RecyclerView>
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textStyle="bold"
+                        android:text="@string/app_headline"
+                        android:fontFamily="sans-serif-light"
+                        android:textSize="16sp"
+                        android:layout_marginLeft="16dp"
+                        android:layout_marginRight="16dp"
+                        android:layout_marginTop="10dp"/>
 
-            </LinearLayout>
-        </android.support.v4.widget.NestedScrollView>
-    </android.support.v4.widget.SwipeRefreshLayout>
+                    <android.support.v7.widget.RecyclerView
+                        android:id="@+id/recyclerView"
+                        android:scrollbars="vertical"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content">
+                    </android.support.v7.widget.RecyclerView>
 
-    <include layout="@layout/error" />
-</android.support.design.widget.CoordinatorLayout>
+                </LinearLayout>
+            </android.support.v4.widget.NestedScrollView>
+        </android.support.v4.widget.SwipeRefreshLayout>
+
+        <include layout="@layout/error" />
+    </LinearLayout>
+
+</layout>

--- a/app/src/main/res/layout/activity_news_detail.xml
+++ b/app/src/main/res/layout/activity_news_detail.xml
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    android:background="@color/colorBackground"
+    tools:context=".view.details.NewsDetailActivity">
+
+    <android.support.design.widget.AppBarLayout
+        android:id="@+id/appbar"
+        android:layout_width="match_parent"
+        android:layout_height="250dp"
+        android:fitsSystemWindows="true"
+        android:theme="@style/MyAppBarLayoutTheme">
+
+        <android.support.design.widget.CollapsingToolbarLayout
+            android:id="@+id/collapsing_toolbar"
+            android:layout_width="match_parent"
+            app:titleEnabled="false"
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="true"
+            app:contentScrim="?attr/colorPrimary"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed">
+
+            <ImageView
+                android:id="@+id/backdrop"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:fitsSystemWindows="true"
+                android:scaleType="centerCrop"
+                app:layout_collapseMode="parallax"
+                android:transitionName="img"
+                tools:ignore="UnusedAttribute" />
+
+            <RelativeLayout
+                android:id="@+id/headerContent"
+                app:layout_collapseMode="pin"
+                android:fitsSystemWindows="true"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_centerInParent="true"
+                android:orientation="vertical">
+
+                <ImageView
+                    android:src="@drawable/top_shadow"
+                    android:scaleType="centerCrop"
+                    android:layout_width="match_parent"
+                    android:layout_height="70dp" />
+
+                <ImageView
+                    android:layout_alignParentBottom="true"
+                    android:src="@drawable/bottom_shadow"
+                    android:id="@+id/img2"
+                    android:layout_alignBottom="@id/img"
+                    android:scaleType="centerCrop"
+                    android:layout_width="match_parent"
+                    android:layout_height="80dp" />
+
+            </RelativeLayout>
+
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:contentInsetStart="0dp"
+                android:contentInsetLeft="0dp"
+                app:contentInsetLeft="0dp"
+                app:contentInsetStart="0dp"
+                app:layout_collapseMode="pin"
+                app:popupTheme="@style/ThemeOverlay.AppCompat.Light">
+
+                <LinearLayout
+                    android:id="@+id/title_appbar"
+                    android:clickable="false"
+                    android:layout_width="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_height="wrap_content">
+
+                    <TextView
+                        android:id="@+id/title_on_appbar"
+                        style="@style/Base.TextAppearance.AppCompat.Widget.ActionBar.Title"
+                        android:text="News for you"
+                        android:textSize="18dp"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:maxLines="1"
+                        android:drawablePadding="10dp"
+                        android:singleLine="true"
+                        android:ellipsize="end"/>
+
+                    <TextView
+                        android:id="@+id/subtitle_on_appbar"
+                        style="@style/Base.TextAppearance.AppCompat.Widget.ActionBar.Subtitle"
+                        android:text="Subtitle"
+                        android:textSize="12dp"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:maxLines="1"
+                        android:drawablePadding="10dp"
+                        android:singleLine="true"
+                        android:ellipsize="end"/>
+
+                </LinearLayout>
+
+            </android.support.v7.widget.Toolbar>
+
+        </android.support.design.widget.CollapsingToolbarLayout>
+
+    </android.support.design.widget.AppBarLayout>
+
+    <android.support.v4.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        android:fitsSystemWindows="true"
+        android:background="@color/colorBackground">
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <android.support.v7.widget.CardView
+                app:layout_behavior="@string/appbar_scrolling_view_behavior"
+                android:layout_width="match_parent"
+                app:cardCornerRadius="0dp"
+                app:cardElevation="@dimen/cardview_default_elevation"
+                android:layout_height="wrap_content">
+                <RelativeLayout
+                    android:layout_marginBottom="20dp"
+                    android:layout_marginTop="20dp"
+                    android:paddingLeft="16dp"
+                    android:paddingRight="16dp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+                    <TextView
+                        android:id="@+id/title"
+                        android:textColor="@color/colorTextTitle"
+                        android:textStyle="bold"
+                        android:fontFamily="sans-serif-light"
+                        android:textSize="19sp"
+                        android:text="Title of News"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        />
+
+                    <TextView
+                        android:id="@+id/time"
+                        android:layout_width="wrap_content"
+                        android:layout_height="20dp"
+                        android:layout_below="@id/title"
+                        android:layout_marginTop="10dp"
+                        android:maxLines="1"
+                        android:drawablePadding="10dp"
+                        android:singleLine="true"
+                        android:ellipsize="end"
+                        android:text="a time ago" />
+
+                </RelativeLayout>
+            </android.support.v7.widget.CardView>
+
+            <android.support.v7.widget.CardView
+                app:layout_behavior="@string/appbar_scrolling_view_behavior"
+                android:layout_marginTop="12dp"
+                android:layout_marginBottom="20dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:cardElevation="@dimen/cardview_default_elevation"
+                app:cardCornerRadius="0dp">
+
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent">
+
+                    <ProgressBar
+                        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+                        android:id="@+id/progress_bar"
+                        android:layout_marginTop="50dp"
+                        android:layout_marginBottom="70dp"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content" />
+
+                    <WebView
+                        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+                        android:id="@+id/webView"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"/>
+
+
+                </RelativeLayout>
+
+            </android.support.v7.widget.CardView>
+
+        </LinearLayout>
+
+    </android.support.v4.widget.NestedScrollView>
+
+    <FrameLayout
+        android:id="@+id/date_behavior"
+        app:layout_anchor="@+id/appbar"
+        app:behavior_autoHide="true"
+        android:adjustViewBounds="true"
+        app:layout_anchorGravity="right|end|bottom"
+        android:clickable="false"
+        android:layout_below="@id/img"
+        android:background="@drawable/round_white"
+        android:layout_width="wrap_content"
+        android:padding="5dp"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentRight="true"
+        android:layout_marginRight="20dp"
+        android:layout_marginBottom="410dp"
+        android:layout_height="wrap_content"
+        tools:ignore="UnusedAttribute">
+        <ImageView
+            android:src="@drawable/ic_date"
+            android:layout_width="18dp"
+            android:layout_height="18dp"
+            android:layout_marginLeft="5dp"
+            android:layout_marginRight="5dp"/>
+        <TextView
+            android:textColor="#606060"
+            android:id="@+id/date"
+            android:layout_marginLeft="27dp"
+            android:layout_marginRight="10dp"
+            android:text="01 January 1990"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+    </FrameLayout>
+
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/error.xml
+++ b/app/src/main/res/layout/error.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:id="@+id/errorLayout"
+    android:paddingLeft="16dp"
+    android:paddingRight="16dp"
+    android:background="@color/colorBackground"
+    android:visibility="gone">
+
+    <ImageView
+        android:id="@+id/errorImage"
+        android:src="@drawable/no_result"
+        android:layout_width="320dp"
+        android:layout_height="320dp"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="64dp"
+        android:contentDescription="@string/error_string" />
+
+    <TextView
+        android:id="@+id/errorTitle"
+        android:text="@string/error_title"
+        android:textColor="@color/colorTextTitle"
+        android:textStyle="bold"
+        android:fontFamily="sans-serif-light"
+        android:layout_centerHorizontal="true"
+        android:layout_below="@id/errorImage"
+        android:gravity="center_horizontal"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <TextView
+        android:id="@+id/errorMessage"
+        android:text="@string/error_message"
+        android:textColor="@color/colorTextSubtitle"
+        android:layout_centerHorizontal="true"
+        android:layout_below="@id/errorTitle"
+        android:gravity="center_horizontal"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+    <Button
+        android:id="@+id/btnRetry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/retry"
+        android:backgroundTint="@color/colorAccent"
+        android:textColor="#fff"
+        android:layout_below="@id/errorMessage"
+        android:layout_marginTop="16dp"
+        android:layout_centerHorizontal="true"/>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/item.xml
+++ b/app/src/main/res/layout/item.xml
@@ -16,6 +16,7 @@
         app:cardElevation="@dimen/cardview_default_elevation">
 
         <RelativeLayout
+            android:background="?android:attr/selectableItemBackground"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -13,10 +13,5 @@
         app:showAsAction="collapseActionView|ifRoom"
         android:theme="@android:style/Theme.Holo.Light.DarkActionBar"/>
 
-    <item
-        android:id="@+id/action_settings"
-        android:orderInCategory="100"
-        android:title="@string/settings"
-        app:showAsAction="never"/>
 
 </menu>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -2,7 +2,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context=".MainActivity">
+    tools:context=".view.MainActivity">
 
     <item
         android:id="@+id/action_search"

--- a/app/src/main/res/menu/menu_share.xml
+++ b/app/src/main/res/menu/menu_share.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/share"
+        android:icon="@drawable/ic_share"
+        android:title="@string/share"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/view_web"
+        android:title="@string/open_with_browser"
+        app:showAsAction="never" />
+
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,4 +22,7 @@
     <string name="no_result">No Result</string>
     <string name="oops">Oops..</string>
     <string name="error_network_failure">Network failure, Please Try Again</string>
+    <string name="sahre_from">Share from the News App</string>
+    <string name="share_with">Share with :</string>
+    <string name="cannot_share">Hmm.. Sorry,  \\nCannot be shared</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,15 @@
     <string name="settings">Settings</string>
     <string name="share">Share</string>
     <string name="open_with_browser">Open with browser</string>
+    <string name="error_string">image representing errors</string>
+    <string name="error_title">Error Title</string>
+    <string name="error_message">Error Message</string>
+    <string name="retry">Retry</string>
+    <string name="error_404">404 not found</string>
+    <string name="error_500">500 server broken</string>
+    <string name="error_unknown">unknown error</string>
+    <string name="try_again">Please Try Again!\n</string>
+    <string name="no_result">No Result</string>
+    <string name="oops">Oops..</string>
+    <string name="error_network_failure">Network failure, Please Try Again</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,6 @@
     <string name="date">01 January 1990</string>
     <string name="search">Search</string>
     <string name="settings">Settings</string>
+    <string name="share">Share</string>
+    <string name="open_with_browser">Open with browser</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,11 +1,19 @@
 <resources>
 
-    <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+    </style>
+
+    <style name="AppTheme.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <style name="MyAppBarLayoutTheme" parent="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+        <item name="colorControlHighlight">@color/colorAccent</item>
     </style>
 
 </resources>


### PR DESCRIPTION
### what should this PR do?
Implement single news Item view in its own page and add functionality for sharing with other people

### How can this be manually tested?
* clone the repo
* cd into the application
* run the app to an emulator or android connected device.
* news will be displayed on the view
* click on a single news item to view it
* click the share option button and choose a medium to share through

### Relevant PT stories
* [News Detail](https://www.pivotaltracker.com/story/show/166218988)
* [Share functionality](https://www.pivotaltracker.com/story/show/166218733)

### ScreenShots
![Screenshot_1558630362](https://user-images.githubusercontent.com/15923109/58271332-7ef30b80-7d94-11e9-8361-5daa6cfdf2fe.png)

![Screenshot_1558630375](https://user-images.githubusercontent.com/15923109/58271333-7ef30b80-7d94-11e9-9e91-40e0e24de3f9.png)

![Screenshot_1558630392](https://user-images.githubusercontent.com/15923109/58271335-7ef30b80-7d94-11e9-8d19-0882e64ed5c4.png)
